### PR TITLE
Fix audio syncing issues on multiplayer.

### DIFF
--- a/CustomBoomboxTracks/Managers/AudioManager.cs
+++ b/CustomBoomboxTracks/Managers/AudioManager.cs
@@ -111,12 +111,15 @@ namespace CustomBoomboxTracks.Managers
         public static void ApplyClips(BoomboxItem __instance)
         {
             BoomboxPlugin.LogInfo($"Applying clips!");
+            AudioClip[] audioClips = clips.ToArray();
+            Array.Sort(audioClips, delegate (AudioClip clip1, AudioClip clip2) { return clip1.name.CompareTo(clip2.name); });
 
             if (Config.UseDefaultSongs)
                 __instance.musicAudios = __instance.musicAudios.Concat(clips).ToArray();
             else
-                __instance.musicAudios = clips.ToArray();
+                __instance.musicAudios = audioClips;
 
+            __instance.musicRandomizer = new System.Random(12345);
             BoomboxPlugin.LogInfo($"Total Clip Count: {__instance.musicAudios.Length}");
         }
 

--- a/CustomBoomboxTracks/Patches/BoomboxItem_Start.cs
+++ b/CustomBoomboxTracks/Patches/BoomboxItem_Start.cs
@@ -6,12 +6,13 @@ namespace CustomBoomboxTracks.Patches
     [HarmonyPatch(typeof(BoomboxItem), "Start")]
     internal class BoomboxItem_Start
     {
-        static void Postfix(BoomboxItem __instance)
+        static bool Prefix(BoomboxItem __instance)
         {
             if (AudioManager.FinishedLoading)
                 AudioManager.ApplyClips(__instance);
             else
                 AudioManager.OnAllSongsLoaded += () => AudioManager.ApplyClips(__instance);
+            return true;
         }
     }
 }


### PR DESCRIPTION
A few changes to fix audio syncing between clients when in multiplayer.
* Sorts imported audio
* Loads the audio files, then runs Start boombox
* Sets the seed for the Audio selection to a fixed value

** Note:** This does require clients/host players to use the same audio files and number of audio files between them.