### PR TITLE
Audio desync fix

### DIFF
--- a/CustomBoomboxTracks/Managers/RandomSyncManager.cs
+++ b/CustomBoomboxTracks/Managers/RandomSyncManager.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CustomBoomboxTracks.Managers {
+    internal class RandomSyncManager {
+        private static List<WeakReference<BoomboxItem>> boomboxes = new List<WeakReference<BoomboxItem>>();
+
+        public static void AddBoombox(BoomboxItem boombox) {
+            BoomboxPlugin.LogInfo($"Adding boombox {boombox.GetHashCode()}");
+            boomboxes.Add(new WeakReference<BoomboxItem>(boombox));
+        }
+
+        public static void ResyncRandomSeed(int mapSeed) {
+            // go over all boomboxes and remove them if they were GC'd
+            boomboxes.RemoveAll(x => {
+                if (x.TryGetTarget(out BoomboxItem boombox)) {
+                    BoomboxPlugin.LogInfo($"Resyncing boombox {boombox.GetHashCode()}");
+                    // mapSeed - 10 because that's what the game does
+                    boombox.musicRandomizer = new Random(mapSeed - 10);
+                    return false;
+                } else {
+                    // boombox was GC'd, remove it
+                    BoomboxPlugin.LogInfo($"A boombox was GC'd");
+                    return true;
+                }
+            });
+        }
+    }
+}

--- a/CustomBoomboxTracks/Patches/BoomboxItem_Start.cs
+++ b/CustomBoomboxTracks/Patches/BoomboxItem_Start.cs
@@ -12,6 +12,8 @@ namespace CustomBoomboxTracks.Patches
                 AudioManager.ApplyClips(__instance);
             else
                 AudioManager.OnAllSongsLoaded += () => AudioManager.ApplyClips(__instance);
+
+            RandomSyncManager.AddBoombox(__instance);
         }
     }
 }

--- a/CustomBoomboxTracks/Patches/RoundManager_GenerateNewLevelClientRpc.cs
+++ b/CustomBoomboxTracks/Patches/RoundManager_GenerateNewLevelClientRpc.cs
@@ -1,0 +1,15 @@
+﻿using CustomBoomboxTracks.Managers;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CustomBoomboxTracks.Patches {
+
+    [HarmonyPatch(typeof(RoundManager), "GenerateNewLevelClientRpc")]
+    internal class RoundManager_GenerateNewLevelClientRpc {
+        static void Postfix(RoundManager __instance) {
+            RandomSyncManager.ResyncRandomSeed(__instance.playersManager.randomMapSeed);
+        }
+    }
+}

--- a/CustomBoomboxTracks/Patches/StartOfRound_OnPlayerConnectedClientRpc.cs
+++ b/CustomBoomboxTracks/Patches/StartOfRound_OnPlayerConnectedClientRpc.cs
@@ -1,0 +1,15 @@
+﻿using CustomBoomboxTracks.Managers;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CustomBoomboxTracks.Patches {
+
+    [HarmonyPatch(typeof(StartOfRound), "OnPlayerConnectedClientRpc")]
+    public class StartOfRound_OnPlayerConnectedClientRpc {
+        static void Postfix(StartOfRound __instance) {
+            RandomSyncManager.ResyncRandomSeed(__instance.randomMapSeed);
+        }
+    }
+}


### PR DESCRIPTION
When a player joins and a boombox already exists, that boombox will be desynced for the player, because the Start method on boombox is called before randomMapSeed is synced.
Also preventively resync boombox to randomMapSeed on new level load if by chance it somehow got desynced.